### PR TITLE
update Statefulset to uses service at dc level (instead of dcRack)

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,6 +25,13 @@ spec:
           ports:
           - containerPort: 60000
             name: metrics
+          readinessProbe:
+            exec:
+              command:
+                - /health
+            failureThreshold: 1
+            initialDelaySeconds: 4
+            periodSeconds: 10
           command:
           - cassandra-k8s-operator
           imagePullPolicy: Always

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -352,7 +352,7 @@ func (cc *CassandraCluster) GetSeedList(seedListTab *[]string) string {
 
 func (cc *CassandraCluster) addNewSeed(seedList *[]string, dcName string, rackName string, indice int32) {
 	dcRackName := cc.GetDCRackName(dcName, rackName)
-	seed := fmt.Sprintf("%s-%s-%d.%s-%s.%s", cc.Name, dcRackName, indice, cc.Name, dcRackName, cc.Namespace)
+	seed := fmt.Sprintf("%s-%s-%d.%s-%s.%s", cc.Name, dcRackName, indice, cc.Name, dcName, cc.Namespace)
 	*seedList = append(*seedList, seed)
 }
 

--- a/pkg/apis/db/v1alpha1/cassandracluster_types_test.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types_test.go
@@ -319,12 +319,12 @@ func TestInitSeedList_2DC(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack1-1.cassandra-demo-online-rack1.ns", cc.Status.SeedList[1])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns", cc.Status.SeedList[2])
-	assert.Equal("cassandra-demo-stats-rack1-0.cassandra-demo-stats-rack1.ns", cc.Status.SeedList[3])
-	assert.Equal("cassandra-demo-stats-rack1-1.cassandra-demo-stats-rack1.ns", cc.Status.SeedList[4])
-	assert.Equal("cassandra-demo-stats-rack2-0.cassandra-demo-stats-rack2.ns", cc.Status.SeedList[5])
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns", cc.Status.SeedList[0])
+	assert.Equal("cassandra-demo-online-rack1-1.cassandra-demo-online.ns", cc.Status.SeedList[1])
+	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online.ns", cc.Status.SeedList[2])
+	assert.Equal("cassandra-demo-stats-rack1-0.cassandra-demo-stats.ns", cc.Status.SeedList[3])
+	assert.Equal("cassandra-demo-stats-rack1-1.cassandra-demo-stats.ns", cc.Status.SeedList[4])
+	assert.Equal("cassandra-demo-stats-rack2-0.cassandra-demo-stats.ns", cc.Status.SeedList[5])
 	assert.Equal(6, len(cc.Status.SeedList))
 }
 
@@ -340,9 +340,9 @@ func TestInitSeedList_NoTopo(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-dc1-rack1-1.cassandra-demo-dc1-rack1.ns", cc.Status.SeedList[1])
-	assert.Equal("cassandra-demo-dc1-rack1-2.cassandra-demo-dc1-rack1.ns", cc.Status.SeedList[2])
+	assert.Equal("cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns", cc.Status.SeedList[0])
+	assert.Equal("cassandra-demo-dc1-rack1-1.cassandra-demo-dc1.ns", cc.Status.SeedList[1])
+	assert.Equal("cassandra-demo-dc1-rack1-2.cassandra-demo-dc1.ns", cc.Status.SeedList[2])
 	assert.Equal(3, len(cc.Status.SeedList))
 
 }
@@ -360,12 +360,12 @@ func TestInitSeedList_1DC(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack1-1.cassandra-demo-online-rack1.ns", cc.Status.SeedList[1])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns", cc.Status.SeedList[2])
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns", cc.Status.SeedList[0])
+	assert.Equal("cassandra-demo-online-rack1-1.cassandra-demo-online.ns", cc.Status.SeedList[1])
+	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online.ns", cc.Status.SeedList[2])
 	assert.Equal(3, len(cc.Status.SeedList))
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns,cassandra-demo-online-rack1-1.cassandra-demo-online-rack1.ns,cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns", cc.GetSeedList(&cc.Status.SeedList))
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns,cassandra-demo-online-rack1-1.cassandra-demo-online.ns,cassandra-demo-online-rack2-0.cassandra-demo-online.ns", cc.GetSeedList(&cc.Status.SeedList))
 
 }
 
@@ -389,15 +389,15 @@ func TestInitSeedList_2DC5R(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns", cc.Status.SeedList[1])
-	assert.Equal("cassandra-demo-online-rack3-0.cassandra-demo-online-rack3.ns", cc.Status.SeedList[2])
-	assert.Equal("cassandra-demo-stats-rack1-0.cassandra-demo-stats-rack1.ns", cc.Status.SeedList[3])
-	assert.Equal("cassandra-demo-stats-rack2-0.cassandra-demo-stats-rack2.ns", cc.Status.SeedList[4])
-	assert.Equal("cassandra-demo-stats-rack3-0.cassandra-demo-stats-rack3.ns", cc.Status.SeedList[5])
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns", cc.Status.SeedList[0])
+	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online.ns", cc.Status.SeedList[1])
+	assert.Equal("cassandra-demo-online-rack3-0.cassandra-demo-online.ns", cc.Status.SeedList[2])
+	assert.Equal("cassandra-demo-stats-rack1-0.cassandra-demo-stats.ns", cc.Status.SeedList[3])
+	assert.Equal("cassandra-demo-stats-rack2-0.cassandra-demo-stats.ns", cc.Status.SeedList[4])
+	assert.Equal("cassandra-demo-stats-rack3-0.cassandra-demo-stats.ns", cc.Status.SeedList[5])
 	assert.Equal(6, len(cc.Status.SeedList))
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns,cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns,cassandra-demo-online-rack3-0.cassandra-demo-online-rack3.ns,cassandra-demo-stats-rack1-0.cassandra-demo-stats-rack1.ns,cassandra-demo-stats-rack2-0.cassandra-demo-stats-rack2.ns,cassandra-demo-stats-rack3-0.cassandra-demo-stats-rack3.ns", cc.GetSeedList(&cc.Status.SeedList))
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns,cassandra-demo-online-rack2-0.cassandra-demo-online.ns,cassandra-demo-online-rack3-0.cassandra-demo-online.ns,cassandra-demo-stats-rack1-0.cassandra-demo-stats.ns,cassandra-demo-stats-rack2-0.cassandra-demo-stats.ns,cassandra-demo-stats-rack3-0.cassandra-demo-stats.ns", cc.GetSeedList(&cc.Status.SeedList))
 }
 
 func TestInitSeedList_1DC1R1P(t *testing.T) {
@@ -413,11 +413,11 @@ func TestInitSeedList_1DC1R1P(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns", cc.Status.SeedList[1])
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns", cc.Status.SeedList[0])
+	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online.ns", cc.Status.SeedList[1])
 	assert.Equal(2, len(cc.Status.SeedList))
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns,cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns", cc.GetSeedList(&cc.Status.SeedList))
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns,cassandra-demo-online-rack2-0.cassandra-demo-online.ns", cc.GetSeedList(&cc.Status.SeedList))
 }
 
 func TestIsPodInSeedList(t *testing.T) {
@@ -431,16 +431,16 @@ func TestIsPodInSeedList(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns", cc.Status.SeedList[1])
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns", cc.Status.SeedList[0])
+	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo-online.ns", cc.Status.SeedList[1])
 	assert.Equal(2, len(cc.Status.SeedList))
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns,cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns", cc.GetSeedList(&cc.Status.SeedList))
+	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo-online.ns,cassandra-demo-online-rack2-0.cassandra-demo-online.ns", cc.GetSeedList(&cc.Status.SeedList))
 
-	assert.Equal(true, cc.IsPodInSeedList("cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns"))
-	assert.Equal(true, cc.IsPodInSeedList("cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns"))
+	assert.Equal(true, cc.IsPodInSeedList("cassandra-demo-online-rack1-0.cassandra-demo-online.ns"))
+	assert.Equal(true, cc.IsPodInSeedList("cassandra-demo-online-rack2-0.cassandra-demo-online.ns"))
 
-	assert.Equal(false, cc.IsPodInSeedList("cassandra-demo-online-rack3-0.cassandra-demo-online-rack2.ns"))
+	assert.Equal(false, cc.IsPodInSeedList("cassandra-demo-online-rack3-0.cassandra-demo-online.ns"))
 
 }
 

--- a/pkg/controller/cassandracluster/cassandra_status_test.go
+++ b/pkg/controller/cassandracluster/cassandra_status_test.go
@@ -88,11 +88,11 @@ func TestUpdateStatusIfSeedListHasChanged(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	var a = []string{"cassandra-demo-online-rack1-0.cassandra-demo-online-rack1.ns",
-		"cassandra-demo-online-rack1-1.cassandra-demo-online-rack1.ns",
-		"cassandra-demo-online-rack2-0.cassandra-demo-online-rack2.ns",
-		"cassandra-demo-stats-rack1-0.cassandra-demo-stats-rack1.ns",
-		"cassandra-demo-stats-rack1-1.cassandra-demo-stats-rack1.ns"}
+	var a = []string{"cassandra-demo-online-rack1-0.cassandra-demo-online.ns",
+		"cassandra-demo-online-rack1-1.cassandra-demo-online.ns",
+		"cassandra-demo-online-rack2-0.cassandra-demo-online.ns",
+		"cassandra-demo-stats-rack1-0.cassandra-demo-stats.ns",
+		"cassandra-demo-stats-rack1-1.cassandra-demo-stats.ns"}
 
 	assert.Equal(5, len(cc.Status.SeedList))
 

--- a/pkg/controller/cassandracluster/deploy_cassandra.go
+++ b/pkg/controller/cassandracluster/deploy_cassandra.go
@@ -98,11 +98,11 @@ func (rcc *ReconcileCassandraCluster) ensureCassandraPodDisruptionBudget(cc *api
 // take dcRackName to accordingly named the statefulset
 // take dc and rack index of dc and rack in conf to retrieve according  nodeselectors labels
 func (rcc *ReconcileCassandraCluster) ensureCassandraStatefulSet(cc *api.CassandraCluster,
-	status *api.CassandraClusterStatus, dcRackName string, dc int, rack int) error {
+	status *api.CassandraClusterStatus, dcName string, dcRackName string, dc int, rack int) error {
 
 	labels, nodeSelector := k8s.GetDCRackLabelsAndNodeSelectorForStatefulSet(cc, dc, rack)
 
-	ss := generateCassandraStatefulSet(cc, status, dcRackName, labels, nodeSelector, nil)
+	ss := generateCassandraStatefulSet(cc, status, dcName, dcRackName, labels, nodeSelector, nil)
 	k8s.AddOwnerRefToObject(ss, k8s.AsOwner(cc))
 
 	err := rcc.CreateOrUpdateStatefulSet(ss, status, dcRackName)

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -208,7 +208,8 @@ func generateVolumeClaimTemplate(cc *api.CassandraCluster, labels map[string]str
 	return pvc
 }
 
-func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.CassandraClusterStatus, dcRackName string,
+func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.CassandraClusterStatus,
+	dcName string, dcRackName string,
 	labels map[string]string, nodeSelector map[string]string, ownerRefs []metav1.OwnerReference) *appsv1.StatefulSet {
 	name := cc.GetName()
 	namespace := cc.Namespace
@@ -250,7 +251,7 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 			OwnerReferences: ownerRefs,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName: name + "-" + dcRackName,
+			ServiceName: name + "-" + dcName,
 			Replicas:    &nodesPerRacks,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: "RollingUpdate",

--- a/pkg/controller/cassandracluster/reconcile.go
+++ b/pkg/controller/cassandracluster/reconcile.go
@@ -378,11 +378,6 @@ func (rcc *ReconcileCassandraCluster) ReconcileRack(cc *api.CassandraCluster,
 					}
 				}
 			}
-
-			if err = rcc.ensureCassandraService(cc, dcName, rackName); err != nil {
-				logrus.WithFields(logrus.Fields{"cluster": cc.Name, "dc-rack": dcRackName}).Errorf("ensureCassandraService Error: %v", err)
-			}
-
 			if err = rcc.ensureCassandraDCService(cc, dcName); err != nil {
 				logrus.WithFields(logrus.Fields{"cluster": cc.Name, "dc-rack": dcRackName}).Errorf("ensureCassandraDCService Error: %v", err)
 			}
@@ -391,7 +386,7 @@ func (rcc *ReconcileCassandraCluster) ReconcileRack(cc *api.CassandraCluster,
 				logrus.WithFields(logrus.Fields{"cluster": cc.Name, "dc-rack": dcRackName}).Errorf("ensureCassandraServiceMonitoring Error: %v", err)
 			}
 
-			if err = rcc.ensureCassandraStatefulSet(cc, status, dcRackName, dc, rack); err != nil {
+			if err = rcc.ensureCassandraStatefulSet(cc, status, dcName, dcRackName, dc, rack); err != nil {
 				logrus.WithFields(logrus.Fields{"cluster": cc.Name, "dc-rack": dcRackName}).Errorf("ensureCassandraStatefulSet Error: %v", err)
 			}
 

--- a/pkg/controller/cassandracluster/reconcile_test.go
+++ b/pkg/controller/cassandracluster/reconcile_test.go
@@ -105,9 +105,9 @@ func TestFlipCassandraClusterUpdateSeedListStatus_ScaleDC2(t *testing.T) {
 	cc.Status.SeedList = cc.InitSeedList()
 
 	var a = []string{
-		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns",
-		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1-rack2.ns",
-		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2-rack1.ns",
+		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2.ns",
 	}
 
 	assert.Equal(3, len(cc.Status.SeedList))
@@ -119,10 +119,10 @@ func TestFlipCassandraClusterUpdateSeedListStatus_ScaleDC2(t *testing.T) {
 	status := cc.Status.DeepCopy()
 
 	var b = []string{
-		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns",
-		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1-rack2.ns",
-		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2-rack1.ns",
-		"cassandra-demo-dc2-rack1-1.cassandra-demo-dc2-rack1.ns",
+		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2.ns",
+		"cassandra-demo-dc2-rack1-1.cassandra-demo-dc2.ns",
 	}
 
 	dc1rack1sts := helperGetStatefulset(t, "dc1-rack1")
@@ -175,9 +175,9 @@ func TestFlipCassandraClusterUpdateSeedListStatus_scaleDC1(t *testing.T) {
 	//1. Init
 	cc.Status.SeedList = cc.InitSeedList()
 	var a = []string{
-		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns",
-		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1-rack2.ns",
-		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2-rack1.ns",
+		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2.ns",
 	}
 	assert.Equal(true, reflect.DeepEqual(a, cc.Status.SeedList))
 
@@ -189,10 +189,10 @@ func TestFlipCassandraClusterUpdateSeedListStatus_scaleDC1(t *testing.T) {
 
 	//Add pod of dc1-rack1 at the end of existing seedlist
 	var b = []string{
-		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns",
-		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1-rack2.ns",
-		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2-rack1.ns",
-		"cassandra-demo-dc1-rack1-1.cassandra-demo-dc1-rack1.ns",
+		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2.ns",
+		"cassandra-demo-dc1-rack1-1.cassandra-demo-dc1.ns",
 	}
 
 	dc1rack1sts := helperGetStatefulset(t, "dc1-rack1")
@@ -235,9 +235,9 @@ func TestFlipCassandraClusterUpdateSeedListStatus_scaleDown(t *testing.T) {
 	//1. Init
 	cc.Status.SeedList = cc.InitSeedList()
 	var a = []string{
-		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns",
-		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1-rack2.ns",
-		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2-rack1.ns",
+		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2.ns",
 	}
 	assert.Equal(true, reflect.DeepEqual(a, cc.Status.SeedList))
 
@@ -250,11 +250,11 @@ func TestFlipCassandraClusterUpdateSeedListStatus_scaleDown(t *testing.T) {
 
 	//Add pod of dc1-rack1 at the end of existing seedlist
 	var b = []string{
-		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns",
-		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1-rack2.ns",
-		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2-rack1.ns",
-		"cassandra-demo-dc1-rack1-1.cassandra-demo-dc1-rack1.ns",
-		"cassandra-demo-dc2-rack1-1.cassandra-demo-dc2-rack1.ns",
+		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2.ns",
+		"cassandra-demo-dc1-rack1-1.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc2-rack1-1.cassandra-demo-dc2.ns",
 	}
 
 	UpdateStatusIfSeedListHasChanged(cc, "dc1-rack1", dc1rack1sts, status)
@@ -289,10 +289,10 @@ func TestFlipCassandraClusterUpdateSeedListStatus_scaleDown(t *testing.T) {
 
 	//expecetd : remove element (dc1-rack1-1) in middle of seedlist
 	var c = []string{
-		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns",
-		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1-rack2.ns",
-		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2-rack1.ns",
-		"cassandra-demo-dc2-rack1-1.cassandra-demo-dc2-rack1.ns",
+		"cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc1-rack2-0.cassandra-demo-dc1.ns",
+		"cassandra-demo-dc2-rack1-0.cassandra-demo-dc2.ns",
+		"cassandra-demo-dc2-rack1-1.cassandra-demo-dc2.ns",
 	}
 
 	UpdateStatusIfSeedListHasChanged(cc, "dc1-rack1", dc1rack1sts, status)

--- a/pkg/controller/cassandracluster/testdata/cassandracluster-2DC-dc1-rack1-sts.yaml
+++ b/pkg/controller/cassandracluster/testdata/cassandracluster-2DC-dc1-rack1-sts.yaml
@@ -33,7 +33,7 @@ spec:
       cassandraclusters.db.orange.com.rack: rack1
       cluster: k8s.pic
       dc-rack: dc1-rack1
-  serviceName: cassandra-demo-dc1-rack1
+  serviceName: cassandra-demo-dc1
   template:
     metadata:
       creationTimestamp: null
@@ -76,7 +76,7 @@ spec:
         - name: CASSANDRA_MAX_HEAP
           value: 512M
         - name: CASSANDRA_SEEDS
-          value: cassandra-demo-dc1-rack1-0.cassandra-demo-dc1-rack1.ns,cassandra-demo-dc1-rack2-0.cassandra-demo-dc1-rack2.ns,cassandra-demo-dc2-rack1-0.cassandra-demo-dc2-rack1.ns
+          value: cassandra-demo-dc1-rack1-0.cassandra-demo-dc1.ns,cassandra-demo-dc1-rack2-0.cassandra-demo-dc1.ns,cassandra-demo-dc2-rack1-0.cassandra-demo-dc2.ns
         - name: CASSANDRA_CLUSTER_NAME
           value: cassandra-demo
         - name: CASSANDRA_AUTO_BOOTSTRAP


### PR DESCRIPTION
-update Statefulset to uses service at dc level (instead of dcRack)
- no more create service at dcRack level

The goal is to supress the dcRack service which makes it difficult to work with Istio

Signed-off-by: sebastien allamand <sebastien.allamand@orange.com>