### PR TITLE
Fix helm chart labels

### DIFF
--- a/helm/cassandra-operator/Chart.yaml
+++ b/helm/cassandra-operator/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/Orange-OpenSource/cassandra-k8s-operator
 sources:
   - https://github.com/Orange-OpenSource/cassandra-k8s-operator
 version: 0.3.1
-appVersion: 0.3.1-mater
+appVersion: 0.3.1-master
 icon: 
 maintainers:
   - name: allamand

--- a/helm/cassandra-operator/templates/db_v1alpha1_cassandracluster_crd.yaml
+++ b/helm/cassandra-operator/templates/db_v1alpha1_cassandracluster_crd.yaml
@@ -2,6 +2,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cassandraclusters.db.orange.com
+  labels:
+    app: {{ template "cassandra-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": crd-install
 spec:

--- a/helm/cassandra-operator/templates/role.yaml
+++ b/helm/cassandra-operator/templates/role.yaml
@@ -3,10 +3,10 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   labels:
-      app: {{ template "cassandra-operator.name" . }}
-      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-      heritage: {{ .Release.Service }}
-      release: {{ .Release.Name }}
+    app: {{ template "cassandra-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
   name: {{ template "cassandra-operator.name" . }}
 rules:
 - apiGroups:

--- a/helm/cassandra-operator/templates/rolebinding.yaml
+++ b/helm/cassandra-operator/templates/rolebinding.yaml
@@ -3,18 +3,13 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-      app: {{ template "cassandra-operator.name" . }}
-      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-      heritage: {{ .Release.Service }}
-      release: {{ .Release.Name }}
+    app: {{ template "cassandra-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
   name: {{ template "cassandra-operator.name" . }}
 subjects:
 - kind: ServiceAccount
-  labels:
-      app: {{ template "cassandra-operator.name" . }}
-      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-      heritage: {{ .Release.Service }}
-      release: {{ .Release.Name }}
   name: {{ template "cassandra-operator.name" . }}
 roleRef:
   kind: Role

--- a/helm/cassandra-operator/templates/service.yaml
+++ b/helm/cassandra-operator/templates/service.yaml
@@ -5,11 +5,10 @@ metadata:
   name: {{ template "cassandra-operator.name" . }}-metrics
   labels:
     component: app
-    labels:
-      app: {{ template "cassandra-operator.name" . }}-metrics
-      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-      heritage: {{ .Release.Service }}
-      release: {{ .Release.Name }}
+    app: {{ template "cassandra-operator.name" . }}-metrics
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   selector:
     app: {{ template "cassandra-operator.name" . }}

--- a/helm/cassandra-operator/templates/service_account.yaml
+++ b/helm/cassandra-operator/templates/service_account.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-      app: {{ template "cassandra-operator.name" . }}
-      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-      heritage: {{ .Release.Service }}
-      release: {{ .Release.Name }}
+    app: {{ template "cassandra-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
   name: {{ template "cassandra-operator.name" . }}


### PR DESCRIPTION
Fix problems related to #17.

Removed 'crd-install' hook because CRDs are installed anyways before other components. See: https://stackoverflow.com/questions/51957676/helm-install-in-certain-order

'crd-install' causes CRD not to be uninstalled by default when release is deleted.

What do you think?