### PR TITLE
add step for adding help incubator repo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -137,13 +137,19 @@ kubectl create namespace cassandra
 
 ### Deploy the Cassandra Operator and it's CRD with Helm
 
-To ease the use of the Cassandra operator, a [Helm](https://helm.sh/) charts has been 
+To ease the use of the Cassandra operator, a [Helm](https://helm.sh/) chart has been 
 created
 
 > We are looking where to store our helm in the future
 
+Add the Helm incubator repo if you do not already have it:
+
+```
+helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+```
 
 Helm is available in the official helm/charts/incubator:
+
 ```
 helm install --name casskop incubator/cassandra-operator
 ```


### PR DESCRIPTION
For users who are not familiar or experienced with Helm, it is not clear from the docs how to access and use the charts from the incubator repo. This PR adds a step for adding the incubator repo.