### PR TITLE
Set createCustomResource: true to default deploying the CRD 

### DIFF
--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -18,6 +18,9 @@ resources:
     cpu: 1
     memory: 512Mi
 
+## If true, create & deploy the CRD
+##
+createCustomResource: true
 
 ## If true, create & use RBAC resources
 ##


### PR DESCRIPTION
This will allow the creation of CRD at the step of deploying casskop through helm.