### PR TITLE
add a note about creating the cassandra-e2e namespace

### DIFF
--- a/documentation/development.md
+++ b/documentation/development.md
@@ -134,6 +134,12 @@ make unit-test
 
 CassKop also have several end-to-end tests that can be run using makefile.
 
+You need to create the namespace `cassandra-e2e` before running the tests.
+
+```
+kubectl create namespace cassandra-e2e
+```
+
 to launch different tests in parallel in different temporary namespaces
 
 ```


### PR DESCRIPTION
I am not sure how things are set up for CI, but for running e2e tests locally I had to first create the `cassandra-e2e` namespace. It would be helpful to have that explicitly stated in the developer docs.