### PR TITLE
jmx exporter name  not match with the one in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -348,7 +348,7 @@ spec:
       - cassandra-demo
       - default
   endpoints:
-  - port: http-promcassjmx
+  - port: promjmx
     interval: 15s
 ```
 

--- a/documentation/description.md
+++ b/documentation/description.md
@@ -1064,7 +1064,7 @@ spec:
       - cassandra
       - cassandra-demo
   endpoints:
-  - port: http-promcassjmx
+  - port: promjmx
     interval: 15s
 ```
 

--- a/samples/prometheus-cassandra-service-monitor.yaml
+++ b/samples/prometheus-cassandra-service-monitor.yaml
@@ -18,7 +18,7 @@ spec:
       - cassandra
       - cassandra-demo
   endpoints:
-  - port: http-promcassjmx
+  - port: promjmx
     interval: 15s
     metricRelabelings:
     - action: replace


### PR DESCRIPTION
the `endpoints.port: http-promcassjmx ` is not match with `promjmx`:
https://github.com/Orange-OpenSource/cassandra-k8s-operator/blob/8e5f0482d7419124986f774e5bfc0077b73456b4/pkg/controller/cassandracluster/deploy_cassandra.go#L43