### PR TITLE
cassandra-stress - Allow more configuration in cassandra-stress mk task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,6 +443,8 @@ endif
 
 REPLICATION_FACTOR ?= 1
 DC ?= dc1
+USERNAME =? cassandra
+PASSWORD =? cassandra
 
 cassandra-stress:
 	kubectl delete configmap cassandra-stress-$(STRESS_TYPE) || true
@@ -453,6 +455,7 @@ cassandra-stress:
 	kubectl delete -f tests/cassandra-stress/cassandra-stress-$(STRESS_TYPE).yaml --wait=false || true
 	while kubectl get pod cassandra-stress-$(STRESS_TYPE)>/dev/null; do echo -n "."; sleep 1 ; done
 	cp tests/cassandra-stress/cassandra-stress-$(STRESS_TYPE).yaml /tmp/
+	sed -i -e 's/user=[a-zA-Z]* password=[a-zA-Z]*/user=$(USERNAME) password=$(PASSWORD)/' /tmp/cassandra-stress-$(STRESS_TYPE).yaml
 ifdef CASSANDRA_IMAGE
 	echo "using Cassandra image $(CASSANDRA_IMAGE)"
 	sed -i -e 's#orangeopensource/cassandra-image.*#$(CASSANDRA_IMAGE)#g' /tmp/cassandra-stress-$(STRESS_TYPE).yaml

--- a/Makefile
+++ b/Makefile
@@ -449,10 +449,19 @@ cassandra-stress:
 	while kubectl get pod cassandra-stress-$(STRESS_TYPE)>/dev/null; do echo -n "."; sleep 1 ; done
 	cp tests/cassandra-stress/cassandra-stress-$(STRESS_TYPE).yaml /tmp/cassandra-stress-$(STRESS_TYPE).yaml
 ifdef CASSANDRA_IMAGE
-	echo "using Cassandra_IMAGE=$(CASSANDRA_IMAGE)"
+	echo "using Cassandra image $(CASSANDRA_IMAGE)"
 	sed -i -e 's#orangeopensource/cassandra-image.*#$(CASSANDRA_IMAGE)#g' /tmp/cassandra-stress-$(STRESS_TYPE).yaml
 endif
 ifdef CASSANDRA_NODE
 	sed -i -e 's/cassandra-demo-dc1.cassandra-demo/$(CASSANDRA_NODE)/g' /tmp/cassandra-stress-$(STRESS_TYPE).yaml
+endif
+ifdef CLUSTER_NAME
+	sed -i -e 's/cassandra-demo/$(CLUSTER_NAME)/g' /tmp/cassandra-stress-$(STRESS_TYPE).yaml
+endif
+ifdef DC
+	sed -i -e 's/dc1/$(DC)/g' /tmp/cassandra-stress-$(STRESS_TYPE).yaml
+endif
+ifdef CONSISTENCY_LEVEL
+	sed -i -e 's/cl=one/cl=$(CONSISTENCY_LEVEL)/g' /tmp/cassandra-stress-$(STRESS_TYPE).yaml
 endif
 	kubectl apply -f /tmp/cassandra-stress-$(STRESS_TYPE).yaml

--- a/Makefile
+++ b/Makefile
@@ -441,12 +441,18 @@ ifeq (cassandra-stress,$(firstword $(MAKECMDGOALS)))
   $(eval $(STRESS_TYPE):;@:)
 endif
 
+REPLICATION_FACTOR ?= 1
+DC ?= dc1
+
 cassandra-stress:
 	kubectl delete configmap cassandra-stress-$(STRESS_TYPE) || true
-	kubectl create configmap cassandra-stress-$(STRESS_TYPE) --from-file=tests/cassandra-stress/$(STRESS_TYPE)_stress.yaml
+	cp tests/cassandra-stress/$(STRESS_TYPE)_stress.yaml /tmp/
+	echo Using replication factor $(REPLICATION_FACTOR) with DC $(DC) in cassandra-stress profile file
+	sed -i -e "s/'dc1': '3'/'$(DC)': '$(REPLICATION_FACTOR)'/" /tmp/$(STRESS_TYPE)_stress.yaml
+	kubectl create configmap cassandra-stress-$(STRESS_TYPE) --from-file=/tmp/$(STRESS_TYPE)_stress.yaml
 	kubectl delete -f tests/cassandra-stress/cassandra-stress-$(STRESS_TYPE).yaml --wait=false || true
 	while kubectl get pod cassandra-stress-$(STRESS_TYPE)>/dev/null; do echo -n "."; sleep 1 ; done
-	cp tests/cassandra-stress/cassandra-stress-$(STRESS_TYPE).yaml /tmp/cassandra-stress-$(STRESS_TYPE).yaml
+	cp tests/cassandra-stress/cassandra-stress-$(STRESS_TYPE).yaml /tmp/
 ifdef CASSANDRA_IMAGE
 	echo "using Cassandra image $(CASSANDRA_IMAGE)"
 	sed -i -e 's#orangeopensource/cassandra-image.*#$(CASSANDRA_IMAGE)#g' /tmp/cassandra-stress-$(STRESS_TYPE).yaml

--- a/tests/cassandra-stress/cassandra-stress-big.yaml
+++ b/tests/cassandra-stress/cassandra-stress-big.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: cassandra-stress-big
   labels:
-    app: cassandra-stress-big
+    app: cassandra-stress
 spec:
   restartPolicy: Never
   volumes:

--- a/tests/cassandra-stress/cassandra-stress-big.yaml
+++ b/tests/cassandra-stress/cassandra-stress-big.yaml
@@ -25,7 +25,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK"]
     command: ["/bin/sh"]
-    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/big_stress.yaml ops(insert=10,query_by_sub_id=8) duration=120m cl=one -node cassandra-demo-dc1.cassandra-demo -mode native cql3 user=bench password=monbench -rate threads=60 -pop seq=0..100M -tokenrange -graph file=/tmp/stress-big.html' && echo END && while true ; do sleep 60; done"]
+    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/big_stress.yaml ops(insert=10,query_by_sub_id=8) duration=120m cl=one -node cassandra-demo -mode native cql3 user=bench password=monbench -rate threads=60 -pop seq=0..100M -tokenrange -graph file=/tmp/stress-big.html' && echo END && while true ; do sleep 60; done"]
     resources:
       limits:
         cpu: "8"

--- a/tests/cassandra-stress/cassandra-stress-huge.yaml
+++ b/tests/cassandra-stress/cassandra-stress-huge.yaml
@@ -25,7 +25,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK"]
     command: ["/bin/sh"]
-    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/huge_stress.yaml ops(insert=10,query_by_sub_id=10) duration=90m cl=one -node cassandra-demo-dc1.cassandra-demo -mode native cql3 user=bench password=monbench -rate threads=50 -pop seq=0..50m -graph file=/tmp/stress-huge1.html' && echo END && while true ; do sleep 60; done"]
+    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/huge_stress.yaml ops(insert=10,query_by_sub_id=10) duration=90m cl=one -node cassandra-demo -mode native cql3 user=bench password=monbench -rate threads=50 -pop seq=0..50m -graph file=/tmp/stress-huge1.html' && echo END && while true ; do sleep 60; done"]
     resources:
       limits:
         cpu: "8"

--- a/tests/cassandra-stress/cassandra-stress-medium.yaml
+++ b/tests/cassandra-stress/cassandra-stress-medium.yaml
@@ -25,7 +25,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK"]
     command: ["/bin/sh"]
-    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/medium_stress.yaml ops(insert=1) n=5m cl=one -node cassandra-demo-dc1.cassandra-demo -mode native cql3 user=cassandra password=cassandra -rate threads=50 -pop seq=0..5m -graph file=/tmp/stress-medium1.html' && echo END && while true ; do sleep 60; done"]
+    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/medium_stress.yaml ops(insert=1) n=5m cl=one -node cassandra-demo -mode native cql3 user=cassandra password=cassandra -rate threads=50 -pop seq=0..5m -graph file=/tmp/stress-medium1.html' && echo END && while true ; do sleep 60; done"]
     resources:
       limits:
         cpu: "8"

--- a/tests/cassandra-stress/cassandra-stress-normal.yaml
+++ b/tests/cassandra-stress/cassandra-stress-normal.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: cassandra-stress-normal
   labels:
-    app: cassandra-stress-normal
+    app: cassandra-stress
 spec:
   restartPolicy: Never
   volumes:

--- a/tests/cassandra-stress/cassandra-stress-normal.yaml
+++ b/tests/cassandra-stress/cassandra-stress-normal.yaml
@@ -25,7 +25,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK"]
     command: ["/bin/sh"]
-    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/normal_stress.yaml ops(insert=10,query_by_sub_id=8) duration=120m cl=one -node cassandra-demo-dc1.cassandra-demo -mode native cql3 user=bench password=monbench -rate threads=30 -pop seq=0..100M -tokenrange -graph file=/tmp/stress-normal.html' && echo END && while true ; do sleep 60; done"]
+    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/normal_stress.yaml ops(insert=10,query_by_sub_id=8) duration=120m cl=one -node cassandra-demo -mode native cql3 user=bench password=monbench -rate threads=30 -pop seq=0..100M -tokenrange -graph file=/tmp/stress-normal.html' && echo END && while true ; do sleep 60; done"]
     resources:
       limits:
         cpu: "8"

--- a/tests/cassandra-stress/cassandra-stress-pig.yaml
+++ b/tests/cassandra-stress/cassandra-stress-pig.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: cassandra-stress-pig
   labels:
-    app: cassandra-stress-pig
+    app: cassandra-stress
 spec:
   restartPolicy: Never
   volumes:

--- a/tests/cassandra-stress/cassandra-stress-pig.yaml
+++ b/tests/cassandra-stress/cassandra-stress-pig.yaml
@@ -25,7 +25,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK"]
     command: ["/bin/sh"]
-    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/pig_stress.yaml ops(insert=1,likelyquery0=1) duration=60m cl=local_one -node cassandra-demo-dc1.cassandra-demo -mode native cql3 user=bench password=monbench -rate threads=30 -graph file=/tmp/stress-pig.html' && echo END && while true ; do sleep 60; done"]
+    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/pig_stress.yaml ops(insert=1,likelyquery0=1) duration=60m cl=local_one -node cassandra-demo -mode native cql3 user=bench password=monbench -rate threads=30 -graph file=/tmp/stress-pig.html' && echo END && while true ; do sleep 60; done"]
     resources:
       limits:
         cpu: "32"

--- a/tests/cassandra-stress/cassandra-stress-small.yaml
+++ b/tests/cassandra-stress/cassandra-stress-small.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: cassandra-stress-small
   labels:
-    app: cassandra-stress-small
+    app: cassandra-stress
 spec:
   restartPolicy: Never
   volumes:

--- a/tests/cassandra-stress/cassandra-stress-small.yaml
+++ b/tests/cassandra-stress/cassandra-stress-small.yaml
@@ -25,8 +25,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK"]
     command: ["/bin/sh"]
-    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/small_stress.yaml ops(insert=2,query_by_sub_id=1) duration=1m cl=one -node cassandra-demo-dc1.cassandra-demo -mode native cql3 user=cassandra password=cassandra -rate threads=20 -pop seq=0..1M -graph file=/tmp/stress-small.html' && echo END && while true ; do sleep 60; done"]
-#    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/small_stress.yaml ops(insert=1,query_by_sub_id=1) n=1m cl=one -node cassandra-demo-dc1.cassandra-demo -mode native cql3 user=cassandra password=cassandra -rate threads=20 -pop seq=0..1M -graph file=/tmp/stress-small.html' && echo END && while true ; do sleep 60; done"]
+    args: ["-c", "cassandra-stress 'user profile=/opt/cassandra-stress/small_stress.yaml ops(insert=2,query_by_sub_id=1) duration=1m cl=one -node cassandra-demo -mode native cql3 user=cassandra password=cassandra -rate threads=20 -pop seq=0..1M -graph file=/tmp/stress-small.html' && echo END && while true ; do sleep 60; done"]
     resources:
       limits:
         cpu: 1

--- a/tests/cassandra-stress/medium_stress.yaml
+++ b/tests/cassandra-stress/medium_stress.yaml
@@ -1,7 +1,7 @@
 keyspace: bench
 
 keyspace_definition: |
-  CREATE KEYSPACE IF NOT EXISTS bench WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': '3', 'dc2': '3'};
+  CREATE KEYSPACE IF NOT EXISTS bench WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': '3'};
 
 table: medium_table
 


### PR DESCRIPTION
Allow users to change several parameters in cassandra-stress run:
- cluster name (CLUSTER_NAME)
- datacenter (DC)
- username (USERNAME)
- password (PASSWORD)
- consistency level (CONSISTENCY_LEVEL)
- replication factor (REPLICATION_FACTOR)

See https://github.com/Orange-OpenSource/cassandra-k8s-operator/blob/39111610632c809d4b2492cd71094618926e552f/Makefile#L444-L447 for default values

As an example, the following command can be used :
`make cassandra-stress small DC=dc1 CLUSTER_NAME=cluster1`