### PR TITLE
Enable dynamic snitch

### DIFF
--- a/samples/cassandra-configmap-v1.yaml
+++ b/samples/cassandra-configmap-v1.yaml
@@ -835,7 +835,7 @@ data:
     # of the snitch, which will be assumed to be on your classpath.
     endpoint_snitch: SimpleSnitch
     
-    dynamic_snitch: false
+    dynamic_snitch: true
     # controls how often to perform the more expensive part of host score
     # calculation
     dynamic_snitch_update_interval_in_ms: 100

--- a/samples/cassandra-configmap-v2.yaml
+++ b/samples/cassandra-configmap-v2.yaml
@@ -835,7 +835,7 @@ data:
     # of the snitch, which will be assumed to be on your classpath.
     endpoint_snitch: SimpleSnitch
     
-    dynamic_snitch: false
+    dynamic_snitch: true
     # controls how often to perform the more expensive part of host score
     # calculation
     dynamic_snitch_update_interval_in_ms: 100


### PR DESCRIPTION
Dynamic snitch is needed to set dynamic_snitch_badness_threshold in case of a rebuild to avoid the node to be queried by customers