### PR TITLE
add statefulset recovery action

### DIFF
--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -79,7 +79,8 @@ const (
 	ActionDeleteDC   string = "ActionDeleteDC"
 	ActionDeleteRack string = "ActionDeleteRack"
 
-	ActionCorrectCRDConfig string = "CorrectCRDConfig" //The Operator has correct a bad CRD configuration
+	ActionRecoverStatefulSet string = "RecoverStatefulset"
+	ActionCorrectCRDConfig   string = "CorrectCRDConfig" //The Operator has correct a bad CRD configuration
 
 	//List of Pods Operations
 	OperationUpgradeSSTables string = "upgradesstables"


### PR DESCRIPTION

I think the reason for https://github.com/Orange-OpenSource/cassandra-k8s-operator/issues/96 is that after deleting the pod, the ```lastClusterAction```  has not been updated,  and ```lastClusterActionStatus``` is always **Done**, so the ```status.Phase``` can not be updated
https://github.com/Orange-OpenSource/cassandra-k8s-operator/blob/73fd24e4d80d853a640defa42b91345cb29847ba/pkg/controller/cassandracluster/reconcile.go#L527
