### PR TITLE
Prevent rack changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.9.0
 	github.com/prometheus/common v0.6.0 // indirect
 	github.com/prometheus/procfs v0.0.3 // indirect
+	github.com/r3labs/diff v0.0.0-20190801153147-a71de73c46ad
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5 // indirect
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,8 @@ github.com/prometheus/procfs v0.0.0-20190403104016-ea9eea638872/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
+github.com/r3labs/diff v0.0.0-20190801153147-a71de73c46ad h1:j5pg/OewZJyE6i3hIG4v3eQUvUyFdQkC8Nd/mjaEkxE=
+github.com/r3labs/diff v0.0.0-20190801153147-a71de73c46ad/go.mod h1:ozniNEFS3j1qCwHKdvraMn1WJOsUxHd7lYfukEIS4cs=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/robfig/cron v0.0.0-20170526150127-736158dc09e1/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -117,7 +117,7 @@ func (cc *CassandraCluster) SetDefaults() bool {
 		if cc.InitCassandraRackList() < 1 {
 			logrus.Errorf("[%s]: We should have at list One Rack, Please correct the Error", cc.Name)
 		}
-		if cc.Status.SeedList == nil{
+		if cc.Status.SeedList == nil {
 			cc.Status.SeedList = cc.InitSeedList()
 		}
 		changed = true
@@ -126,7 +126,7 @@ func (cc *CassandraCluster) SetDefaults() bool {
 		ccs.MaxPodUnavailable = defaultMaxPodUnavailable
 	}
 	if cc.Spec.Resources.Limits == (CPUAndMem{}) {
-		cc.Spec.Resources.Limits = cc.Spec.Resources.Requests;
+		cc.Spec.Resources.Limits = cc.Spec.Resources.Requests
 		changed = true
 	}
 
@@ -196,7 +196,7 @@ func (cc *CassandraCluster) getDCNumTokensPerRacksFromIndex(dc int) int32 {
 	return *storeDC.NumTokens
 }
 
-//GetRAckSize return the numbers of the Rack in the DCat indice dc
+//GetRackSize return the numbers of the Rack in the DC at indice dc
 func (cc *CassandraCluster) GetRackSize(dc int) int {
 	if dc >= cc.GetDCSize() {
 		return 0
@@ -446,7 +446,6 @@ func (cc *CassandraCluster) GetNodesPerRacks(dcRackName string) int32 {
 	nodesPerRacks := cc.GetDCNodesPerRacksFromDCRackName(dcRackName)
 	return nodesPerRacks
 }
-
 
 //GetDCNodesPerRacksFromDCRackName send NodesPerRack used for the given dcRackName
 func (cc *CassandraCluster) GetDCRackNames() []string {

--- a/pkg/controller/cassandracluster/cassandracluster_controller.go
+++ b/pkg/controller/cassandracluster/cassandracluster_controller.go
@@ -142,7 +142,7 @@ func (rcc *ReconcileCassandraCluster) Reconcile(request reconcile.Request) (reco
 	//We Update Status at the end
 	defer rcc.updateCassandraStatus(cc, status)
 
-	//If non allowed changes on CRD, we exit until an operator fix the CRD
+	//If non allowed changes on CRD, we return here
 	if rcc.CheckNonAllowedChanges(cc, status) {
 		return requeue30, nil
 	}

--- a/pkg/controller/cassandracluster/cassandracluster_controller.go
+++ b/pkg/controller/cassandracluster/cassandracluster_controller.go
@@ -143,7 +143,7 @@ func (rcc *ReconcileCassandraCluster) Reconcile(request reconcile.Request) (reco
 	defer rcc.updateCassandraStatus(cc, status)
 
 	//If non allowed changes on CRD, we exit until an operator fix the CRD
-	if rcc.CheckNonAllowedChanged(cc, status) {
+	if rcc.CheckNonAllowedChanges(cc, status) {
 		return requeue30, nil
 	}
 

--- a/pkg/controller/cassandracluster/reconcile.go
+++ b/pkg/controller/cassandracluster/reconcile.go
@@ -211,12 +211,12 @@ func hasChange(changelog diff.Changelog, changeType string, paths ...string) boo
 	noPaths := len(paths) == 0
 	includeFilters := [][]string{}
 	excludeFilters := [][]string{}
-	for _, p := range paths {
-		if match := regexPath.FindStringSubmatch(p); len(match) > 0 {
+	for _, path := range paths {
+		if match := regexPath.FindStringSubmatch(path); len(match) > 0 {
 			excludeFilters = append(excludeFilters, generatePaths(match[1]))
 			continue
 		}
-		includeFilters = append(includeFilters, generatePaths(p))
+		includeFilters = append(includeFilters, generatePaths(path))
 	}
 	idx := "-1"
 	includedFiltersFound := map[string]bool{}

--- a/pkg/controller/cassandracluster/reconcile.go
+++ b/pkg/controller/cassandracluster/reconcile.go
@@ -184,15 +184,17 @@ func generatePaths(s string) []string {
 	return strings.Split(s, ".")
 }
 
-func lookForFilter(filter, path []string, filtersFound *map[string]bool) {
-	if 2*len(filter)+1 == len(path) {
-		currentPath := path[0]
-		for i := 2; i < len(path)-1; i += 2 {
-			currentPath += "." + path[i]
-		}
-		if currentPath == strings.Join(filter, ".") {
-			if _, ok := (*filtersFound)[currentPath]; !ok {
-				(*filtersFound)[currentPath] = true
+func lookForFilter(path []string, filtersRule [][]string, filtersFound *map[string]bool) {
+	for _, filter := range filtersRule {
+		if 2*len(filter)+1 == len(path) {
+			currentPath := path[0]
+			for i := 2; i < len(path)-1; i += 2 {
+				currentPath += "." + path[i]
+			}
+			if currentPath == strings.Join(filter, ".") {
+				if _, ok := (*filtersFound)[currentPath]; !ok {
+					(*filtersFound)[currentPath] = true
+				}
 			}
 		}
 	}
@@ -232,13 +234,10 @@ func hasChange(changelog diff.Changelog, changeType string, paths ...string) boo
 
 			}
 			// We look for all matching filters
-			for _, filter := range includeFilters {
-				lookForFilter(filter, cl.Path, &includedFiltersFound)
-			}
+			lookForFilter(cl.Path, includeFilters, &includedFiltersFound)
+
 			// We look for all excluding filters
-			for _, filter := range excludeFilters {
-				lookForFilter(filter, cl.Path, &excludedFiltersFound)
-			}
+			lookForFilter(cl.Path, excludeFilters, &excludedFiltersFound)
 
 			if len(includedFiltersFound) == len(includeFilters) && len(excludedFiltersFound) == 0 {
 				return true

--- a/pkg/controller/cassandracluster/reconcile.go
+++ b/pkg/controller/cassandracluster/reconcile.go
@@ -225,7 +225,12 @@ func hasChange(changelog diff.Changelog, changeType string, paths ...string) boo
 	idx := "-1"
 	var includedFiltersFound, excludedFiltersFound map[string]bool
 	for _, cl := range changelog {
-		if cl.Type == changeType && cl.Path[2] != "NodesPerRacks" {
+		// Only scan changes on Name/NumTokens
+		if cl.Type == changeType &&
+			// DC Changes
+			(cl.Path[2] == "Name" || cl.Path[2] == "NumTokens" ||
+				// Rack changes
+				(len(cl.Path) > 4 && cl.Path[4] == "Name")) {
 			if noPaths {
 				return true
 			}

--- a/pkg/controller/cassandracluster/reconcile.go
+++ b/pkg/controller/cassandracluster/reconcile.go
@@ -220,7 +220,7 @@ func hasChange(changelog diff.Changelog, changeType string, paths ...string) boo
 	includedFiltersFound := map[string]bool{}
 	excludedFiltersFound := map[string]bool{}
 	for _, cl := range changelog {
-		if cl.Type == changeType {
+		if cl.Type == changeType && cl.Path[2] != "NodesPerRacks" {
 			if noPaths {
 				return true
 			}

--- a/pkg/controller/cassandracluster/reconcile.go
+++ b/pkg/controller/cassandracluster/reconcile.go
@@ -74,10 +74,10 @@ func (rcc *ReconcileCassandraCluster) CheckDeletePVC(cc *api.CassandraCluster) e
 	return nil
 }
 
-// CheckNonAllowedChanged - checks if there are some changes on CRD that are not allowed on statefulset
+// CheckNonAllowedChanges - checks if there are some changes on CRD that are not allowed on statefulset
 // If a non Allowed Changed is Find we won't Update associated kubernetes objects, but we will put back the old value
 // and Patch the CRD with correct values
-func (rcc *ReconcileCassandraCluster) CheckNonAllowedChanged(cc *api.CassandraCluster,
+func (rcc *ReconcileCassandraCluster) CheckNonAllowedChanges(cc *api.CassandraCluster,
 	status *api.CassandraClusterStatus) bool {
 	var oldCRD api.CassandraCluster
 	if cc.Annotations[api.AnnotationLastApplied] == "" {
@@ -127,7 +127,7 @@ func (rcc *ReconcileCassandraCluster) CheckNonAllowedChanged(cc *api.CassandraCl
 	}
 
 	var updateStatus string
-	if needUpdate, updateStatus = CheckNonAllowedRemoveDC(rcc, cc, status, &oldCRD); needUpdate {
+	if needUpdate, updateStatus = CheckNonAllowedDCChanges(rcc, cc, status, &oldCRD); needUpdate {
 		if updateStatus != "" {
 			status.LastClusterAction = updateStatus
 		}

--- a/pkg/controller/cassandracluster/reconcile_test.go
+++ b/pkg/controller/cassandracluster/reconcile_test.go
@@ -521,12 +521,12 @@ func TestCheckNonAllowedChangesScaleDown(t *testing.T) {
 			Name:      "cassandra-demo-dc2-rack1-0",
 			Namespace: "ns",
 			Labels: map[string]string{
-				"app": "cassandracluster",
-				"cassandracluster": "cassandra-demo",
-				"cassandraclusters.db.orange.com.dc": "dc2",
+				"app":                                  "cassandracluster",
+				"cassandracluster":                     "cassandra-demo",
+				"cassandraclusters.db.orange.com.dc":   "dc2",
 				"cassandraclusters.db.orange.com.rack": "rack1",
-				"cluster": "k8s.pic",
-				"dc-rack": "dc2-rack1",
+				"cluster":                              "k8s.pic",
+				"dc-rack":                              "dc2-rack1",
 			},
 		},
 	}

--- a/pkg/controller/cassandracluster/reconcile_test.go
+++ b/pkg/controller/cassandracluster/reconcile_test.go
@@ -91,7 +91,7 @@ func helperGetStatefulset(t *testing.T, dcRackName string) *appsv1.StatefulSet {
 	return &sts
 }
 
-func TestFlipCassandraClusterUpdateSeedListStatus_ScaleDC2(t *testing.T) {
+func TestFlipCassandraClusterUpdateSeedListStatusScaleDC2(t *testing.T) {
 	assert := assert.New(t)
 
 	_, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
@@ -163,10 +163,9 @@ func TestFlipCassandraClusterUpdateSeedListStatus_ScaleDC2(t *testing.T) {
 
 	assert.Equal(4, len(status.SeedList))
 	assert.Equal(true, reflect.DeepEqual(b, status.SeedList))
-
 }
 
-func TestFlipCassandraClusterUpdateSeedListStatus_scaleDC1(t *testing.T) {
+func TestFlipCassandraClusterUpdateSeedListStatusscaleDC1(t *testing.T) {
 	assert := assert.New(t)
 
 	_, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
@@ -221,10 +220,9 @@ func TestFlipCassandraClusterUpdateSeedListStatus_scaleDC1(t *testing.T) {
 	assert.Equal(api.StatusToDo, status.CassandraRackStatus["dc2-rack1"].CassandraLastAction.Status)
 
 	assert.Equal(true, reflect.DeepEqual(b, status.SeedList))
-
 }
 
-func TestFlipCassandraClusterUpdateSeedListStatus_scaleDown(t *testing.T) {
+func TestFlipCassandraClusterUpdateSeedListStatusScaleDown(t *testing.T) {
 	assert := assert.New(t)
 
 	_, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
@@ -316,11 +314,10 @@ func TestFlipCassandraClusterUpdateSeedListStatus_scaleDown(t *testing.T) {
 	assert.Equal(api.StatusToDo, status.CassandraRackStatus["dc2-rack1"].CassandraLastAction.Status)
 
 	assert.Equal(true, reflect.DeepEqual(c, status.SeedList))
-
 }
 
 //mock example https://github.com/operator-framework/operator-sdk/blob/e74dd322b291b111f78702cf71e5ac843a0c8912/doc/user/unit-testing.md
-func TestCheckNonAllowedChanges_NodesTo0(t *testing.T) {
+func TestCheckNonAllowedChangesNodesTo0(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
@@ -336,10 +333,9 @@ func TestCheckNonAllowedChanges_NodesTo0(t *testing.T) {
 	res = rcc.CheckNonAllowedChanges(cc, status)
 	assert.Equal(true, res)
 	assert.Equal(int32(1), cc.Spec.NodesPerRacks)
-
 }
 
-func TestCheckNonAllowedChanges_Mix1(t *testing.T) {
+func TestCheckNonAllowedChangesMix1(t *testing.T) {
 	assert := assert.New(t)
 	rcc, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
 	status := cc.Status.DeepCopy()
@@ -363,10 +359,9 @@ func TestCheckNonAllowedChanges_Mix1(t *testing.T) {
 
 	//Allow Change
 	assert.Equal(false, cc.Spec.AutoPilot)
-
 }
 
-func TestCheckNonAllowedChanges_ResourcesIsAllowedButNeedAttention(t *testing.T) {
+func TestCheckNonAllowedChangesResourcesIsAllowedButNeedAttention(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
@@ -393,28 +388,25 @@ func TestCheckNonAllowedChanges_ResourcesIsAllowedButNeedAttention(t *testing.T)
 	dcRackName = "dc2-rack1"
 	assert.Equal(api.ActionUpdateResources, status.CassandraRackStatus[dcRackName].CassandraLastAction.Name)
 	assert.Equal(api.StatusToDo, status.CassandraRackStatus[dcRackName].CassandraLastAction.Status)
-
 }
 
-//Remove 2 dc is not allowed
-func TestCheckNonAllowedChanges_Remove2DC(t *testing.T) {
+func TestCheckNonAllowedChangesRemove2DC(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
 	status := cc.Status.DeepCopy()
 	rcc.updateCassandraStatus(cc, status)
 
-	//Remove 1 rack/dc at specified index
 	cc.Spec.Topology.DC.Remove(2)
 	cc.Spec.Topology.DC.Remove(1)
 
+	// We can't remove more than one DC at once
 	res := rcc.CheckNonAllowedChanges(cc, status)
 	assert.Equal(true, res)
-
 }
 
 //Updating racks is not allowed
-func TestCheckNonAllowedChanges_UpdateRack(t *testing.T) {
+func TestCheckNonAllowedChangesUpdateRack(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
@@ -448,11 +440,10 @@ func TestCheckNonAllowedChanges_UpdateRack(t *testing.T) {
 
 	//Topology must have been restored
 	assert.Equal(4, cc.GetDCRackSize())
-
 }
 
 //remove only a rack is not allowed
-func TestCheckNonAllowedChanges_RemoveDCNot0(t *testing.T) {
+func TestCheckNonAllowedChangesRemoveDCNot0(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
@@ -474,10 +465,9 @@ func TestCheckNonAllowedChanges_RemoveDCNot0(t *testing.T) {
 
 	//Topology must have been restored
 	assert.Equal(4, cc.GetDCRackSize())
-
 }
 
-func TestCheckNonAllowedChanges_RemoveDC(t *testing.T) {
+func TestCheckNonAllowedChangesRemoveDC(t *testing.T) {
 	assert := assert.New(t)
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
 
@@ -511,10 +501,10 @@ func TestCheckNonAllowedChanges_RemoveDC(t *testing.T) {
 	assert.Equal(3, len(status.CassandraRackStatus))
 }
 
-// TestCheckNonAllowedChanges_ScaleDown test that operator won't allowed a Scale Down to 0 if there are Pods in dc and
+// TestCheckNonAllowedChangesScaleDown test that operator won't allowed a Scale Down to 0 if there are Pods in dc and
 // still has datas replicated
 //Uses K8s fake client, & Jolokia Mock
-func TestCheckNonAllowedChanges_ScaleDown(t *testing.T) {
+func TestCheckNonAllowedChangesScaleDown(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")

--- a/pkg/controller/cassandracluster/reconcile_test.go
+++ b/pkg/controller/cassandracluster/reconcile_test.go
@@ -441,7 +441,6 @@ func TestCheckNonAllowedChanges_RemoveDCNot0(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
-	//Simulate old spec with nodes at 0
 
 	status := cc.Status.DeepCopy()
 	rcc.updateCassandraStatus(cc, status)
@@ -587,8 +586,8 @@ func TestCheckNonAllowedChanges_ScaleDown(t *testing.T) {
 
 	//--Step 3
 	//Changes replicated keyspaces (remove demo1 and demo2 which still have replicated datas
-	//all Keyspace is global test var
-	allKeyspaces = []string{"system", "system_auth", "system_schema", "truc", "muche"}
+	//allKeyspaces is a global test variable
+	allKeyspaces = []string{"system", "system_auth", "system_schema", "something", "else"}
 	cc.Spec.Topology.DC[1].NodesPerRacks = &nb
 
 	res = rcc.CheckNonAllowedChanges(cc, status)

--- a/pkg/controller/cassandracluster/reconcile_test.go
+++ b/pkg/controller/cassandracluster/reconcile_test.go
@@ -638,4 +638,13 @@ func TestHasChange(t *testing.T) {
 	assert.True(hasChange(changelog, diff.UPDATE, "DC"))
 	assert.False(hasChange(changelog, diff.UPDATE, "-DC", "DC.Rack"))
 	assert.False(hasChange(changelog, diff.CREATE))
+
+	changelog = []diff.Change{
+		{Type: diff.UPDATE, Path: []string{"DC", "1", "Rack", "2", "RollingRestart"}},
+		{Type: diff.UPDATE, Path: []string{"DC", "1", "NodesPerRacks"}},
+	}
+
+	assert.False(hasChange(changelog, diff.UPDATE, "DC"))
+	assert.False(hasChange(changelog, diff.UPDATE, "DC.Rack"))
+
 }

--- a/pkg/controller/cassandracluster/reconcile_test.go
+++ b/pkg/controller/cassandracluster/reconcile_test.go
@@ -319,7 +319,7 @@ func TestFlipCassandraClusterUpdateSeedListStatus_scaleDown(t *testing.T) {
 }
 
 //mock example https://github.com/operator-framework/operator-sdk/blob/e74dd322b291b111f78702cf71e5ac843a0c8912/doc/user/unit-testing.md
-func TestCheckNonAllowedChanged_NodesTo0(t *testing.T) {
+func TestCheckNonAllowedChanges_NodesTo0(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
@@ -327,18 +327,18 @@ func TestCheckNonAllowedChanged_NodesTo0(t *testing.T) {
 	status := cc.Status.DeepCopy()
 	rcc.updateCassandraStatus(cc, status)
 
-	res := rcc.CheckNonAllowedChanged(cc, status)
+	res := rcc.CheckNonAllowedChanges(cc, status)
 	assert.Equal(false, res)
 
 	//Global ScaleDown to 0 must be ignored
 	cc.Spec.NodesPerRacks = 0
-	res = rcc.CheckNonAllowedChanged(cc, status)
+	res = rcc.CheckNonAllowedChanges(cc, status)
 	assert.Equal(true, res)
 	assert.Equal(int32(1), cc.Spec.NodesPerRacks)
 
 }
 
-func TestCheckNonAllowedChanged_Mix1(t *testing.T) {
+func TestCheckNonAllowedChanges_Mix1(t *testing.T) {
 	assert := assert.New(t)
 	rcc, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
 	status := cc.Status.DeepCopy()
@@ -352,7 +352,7 @@ func TestCheckNonAllowedChanged_Mix1(t *testing.T) {
 	//Allow Changed
 	cc.Spec.AutoPilot = false //instead of true
 
-	res := rcc.CheckNonAllowedChanged(cc, status)
+	res := rcc.CheckNonAllowedChanges(cc, status)
 	assert.Equal(true, res)
 
 	//Forbidden Changes
@@ -365,7 +365,7 @@ func TestCheckNonAllowedChanged_Mix1(t *testing.T) {
 
 }
 
-func TestCheckNonAllowedChanged_ResourcesIsAllowedButNeedAttention(t *testing.T) {
+func TestCheckNonAllowedChanges_ResourcesIsAllowedButNeedAttention(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
@@ -377,7 +377,7 @@ func TestCheckNonAllowedChanged_ResourcesIsAllowedButNeedAttention(t *testing.T)
 	cc.Spec.Resources.Requests.CPU = "2"      //instead of '1'
 	cc.Spec.Resources.Requests.Memory = "2Gi" //instead of 2Gi
 
-	res := rcc.CheckNonAllowedChanged(cc, status)
+	res := rcc.CheckNonAllowedChanges(cc, status)
 	assert.Equal(false, res)
 
 	assert.Equal("2", cc.Spec.Resources.Requests.CPU)
@@ -396,7 +396,7 @@ func TestCheckNonAllowedChanged_ResourcesIsAllowedButNeedAttention(t *testing.T)
 }
 
 //Remove 2 dc is not allowed
-func TestCheckNonAllowedChanged_Remove2DC(t *testing.T) {
+func TestCheckNonAllowedChanges_Remove2DC(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
@@ -407,13 +407,13 @@ func TestCheckNonAllowedChanged_Remove2DC(t *testing.T) {
 	cc.Spec.Topology.DC.Remove(2)
 	cc.Spec.Topology.DC.Remove(1)
 
-	res := rcc.CheckNonAllowedChanged(cc, status)
+	res := rcc.CheckNonAllowedChanges(cc, status)
 	assert.Equal(true, res)
 
 }
 
 //remove only a rack is not allowed
-func TestCheckNonAllowedChanged_RemoveRack(t *testing.T) {
+func TestCheckNonAllowedChanges_RemoveRack(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
@@ -424,7 +424,7 @@ func TestCheckNonAllowedChanged_RemoveRack(t *testing.T) {
 	//Remove 1 rack/dc at specified index
 	cc.Spec.Topology.DC[0].Rack.Remove(1)
 
-	res := rcc.CheckNonAllowedChanged(cc, status)
+	res := rcc.CheckNonAllowedChanges(cc, status)
 	assert.Equal(true, res)
 
 	//Topology must have been restored
@@ -436,7 +436,7 @@ func TestCheckNonAllowedChanged_RemoveRack(t *testing.T) {
 }
 
 //remove only a rack is not allowed
-func TestCheckNonAllowedChanged_RemoveDCNot0(t *testing.T) {
+func TestCheckNonAllowedChanges_RemoveDCNot0(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
@@ -449,7 +449,7 @@ func TestCheckNonAllowedChanged_RemoveDCNot0(t *testing.T) {
 	//Remove 1 rack/dc at specified index
 	cc.Spec.Topology.DC.Remove(1)
 
-	res := rcc.CheckNonAllowedChanged(cc, status)
+	res := rcc.CheckNonAllowedChanges(cc, status)
 
 	//Change not allowed because dc still has nodes
 	assert.Equal(true, res)
@@ -462,7 +462,7 @@ func TestCheckNonAllowedChanged_RemoveDCNot0(t *testing.T) {
 
 }
 
-func TestCheckNonAllowedChanged_RemoveDC(t *testing.T) {
+func TestCheckNonAllowedChanges_RemoveDC(t *testing.T) {
 	assert := assert.New(t)
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
 	//Simulate old spec with nodes at 0
@@ -477,7 +477,7 @@ func TestCheckNonAllowedChanged_RemoveDC(t *testing.T) {
 	//Remove 1 rack/dc at specified index
 	cc.Spec.Topology.DC.Remove(1)
 
-	res := rcc.CheckNonAllowedChanged(cc, status)
+	res := rcc.CheckNonAllowedChanges(cc, status)
 
 	//Change not allowed because dc still has nodes
 	assert.Equal(true, res)
@@ -493,10 +493,10 @@ func TestCheckNonAllowedChanged_RemoveDC(t *testing.T) {
 
 }
 
-// TestCheckNonAllowedChanged_ScaleDown test that operator won't allowed a Scale Down to 0 if there are Pods in dc and
+// TestCheckNonAllowedChanges_ScaleDown test that operator won't allowed a Scale Down to 0 if there are Pods in dc and
 // still has datas replicated
 //Uses K8s fake client, & Jolokia Mock
-func TestCheckNonAllowedChanged_ScaleDown(t *testing.T) {
+func TestCheckNonAllowedChanges_ScaleDown(t *testing.T) {
 	assert := assert.New(t)
 
 	rcc, cc := helperInitCluster(t, "cassandracluster-3DC.yaml")
@@ -576,7 +576,7 @@ func TestCheckNonAllowedChanged_ScaleDown(t *testing.T) {
 	var nb int32
 	cc.Spec.Topology.DC[1].NodesPerRacks = &nb
 
-	res := rcc.CheckNonAllowedChanged(cc, status)
+	res := rcc.CheckNonAllowedChanges(cc, status)
 	rcc.updateCassandraStatus(cc, status)
 	//Change not allowed because dc still has nodes
 	assert.Equal(true, res)
@@ -590,7 +590,7 @@ func TestCheckNonAllowedChanged_ScaleDown(t *testing.T) {
 	allKeyspaces = []string{"system", "system_auth", "system_schema", "truc", "muche"}
 	cc.Spec.Topology.DC[1].NodesPerRacks = &nb
 
-	res = rcc.CheckNonAllowedChanged(cc, status)
+	res = rcc.CheckNonAllowedChanges(cc, status)
 
 	//Change  allowed because there is no more keyspace with replicated datas
 	assert.Equal(false, res)


### PR DESCRIPTION
This PR introduces the use of https://github.com/r3labs/diff to handle topology changes. A few functions were written to be handle to change changes and be able to check conditions. 
Other unit tests were added to test the function `hasChange` and unit tests were renamed to use Go naming convention.

Those changes were then used to prevent rack changes.