### PR TITLE
helm: Adds crds folder in order to install crds with helm v3

### DIFF
--- a/helm/cassandra-operator/Chart.yaml
+++ b/helm/cassandra-operator/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for CassKop - the Orange Cassandra Kubernetes operator
 name: cassandra-operator
 home: https://github.com/Orange-OpenSource/cassandra-k8s-operator

--- a/helm/cassandra-operator/crds/db_v1alpha1_cassandracluster_crd.yaml
+++ b/helm/cassandra-operator/crds/db_v1alpha1_cassandracluster_crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cassandraclusters.db.orange.com
+spec:
+  group: db.orange.com
+  names:
+    kind: CassandraCluster
+    listKind: CassandraClusterList
+    plural: cassandraclusters
+    singular: cassandracluster
+  scope: Namespaced
+  version: v1alpha1


### PR DESCRIPTION
There was a breaking change between helm v2 and v3 with crd management.
Helm v2 was using a "crd-install" hook, that no longer exists.
Instead, Helm v3 will install all resources contained in the "crds"
directory before rendering templates.

Fixes #132 