### PR TITLE
controller: Adds support for Tolerations

### DIFF
--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -761,6 +761,8 @@ type Rack struct {
 type PodPolicy struct {
 	// Annotations specifies the annotations to attach to headless service the CassKop operator creates
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Tolerations specifies the tolerations to attach to the pods the CassKop operator creates
+	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 }
 
 // PodPolicy defines the policy for headless service owned by CassKop operator.

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -250,8 +250,10 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 	rollingPartition := cc.GetRollingPartitionPerRacks(dcRackName)
 	terminationPeriod := int64(api.DefaultTerminationGracePeriodSeconds)
 	var annotations = map[string]string{}
+	var tolerations = []v1.Toleration{}
 	if cc.Spec.Pod != nil {
 		annotations = cc.Spec.Pod.Annotations
+		tolerations = cc.Spec.Pod.Tolerations
 	}
 
 	ss := &appsv1.StatefulSet{
@@ -287,6 +289,7 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 						NodeAffinity:    nodeAffinity,
 						PodAntiAffinity: createPodAntiAffinity(cc.Spec.HardAntiAffinity, k8s.LabelsForCassandra(cc)),
 					},
+					Tolerations: tolerations,
 					SecurityContext: &v1.PodSecurityContext{
 						RunAsUser:    cc.Spec.RunAsUser,
 						RunAsNonRoot: func(b bool) *bool { return &b }(true),

--- a/pkg/controller/cassandracluster/generator_test.go
+++ b/pkg/controller/cassandracluster/generator_test.go
@@ -143,4 +143,9 @@ func TestGenerateCassandraStatefulSet(t *testing.T) {
 		"cluster":                              "k8s.pic"},
 		sts.Labels)
 	assert.Equal("my.custom.annotation", sts.Spec.Template.Annotations["exemple.com/test"])
+	assert.Equal([]v1.Toleration{v1.Toleration{
+		Key: "my_custom_taint",
+		Operator: v1.TolerationOpExists,
+		Effect: v1.TaintEffectNoSchedule}},
+		sts.Spec.Template.Spec.Tolerations)
 }

--- a/pkg/controller/cassandracluster/testdata/cassandracluster-2DC.yaml
+++ b/pkg/controller/cassandracluster/testdata/cassandracluster-2DC.yaml
@@ -18,6 +18,10 @@ spec:
   pod:
     annotations:
       exemple.com/test: my.custom.annotation
+    tolerations:
+      - key: my_custom_taint
+        operator: Exists
+        effect: NoSchedule
   dataCapacity: "3Gi"
   dataStorageClass: "local-storage"
   hardAntiAffinity: false


### PR DESCRIPTION
This allows to adds tolerations to the pod template
of the statefulset created by the operator.
It is necessary if you want to allow scheduling thoses pods
on tainted nodes.

Fixes #136