### PR TITLE
Allow Istio to work with Cassandra and encrypt native connections

### DIFF
--- a/docker/bootstrap/Dockerfile
+++ b/docker/bootstrap/Dockerfile
@@ -48,10 +48,6 @@ LABEL \
     org.label-schema.usage='/README.md'
 
 
-#        libcap2-bin \
-#        procps \
-#        dnsutils && \
-
 RUN mkdir -p $CASSANDRA_DATA  $CASSANDRA_CONF $BOOTSTRAP_CONF $BOOTSTRAP_LIBS $CASSANDRA_LIBS /tmp && \
     set -ex; \
     apt-get update && apt-get -qq -y install --no-install-recommends \

--- a/docker/bootstrap/bootstrap.sh
+++ b/docker/bootstrap/bootstrap.sh
@@ -7,18 +7,18 @@ cp -rLv /${BOOTSTRAP_CONF}/* /etc/cassandra/
 # If User has submited a configMap, we uses them to deplace default ones
 # (overwriting the above)
 if [[ -d ${CONFIGMAP} && ! -z `ls -A ${CONFIGMAP}` ]] ; then
-    echo " == We have a ConfigMap, we surcharge default configuration files"
+    echo "We have a ConfigMap, we surcharge default configuration files"
     cp -rLv ${CONFIGMAP}/* /etc/cassandra/
 fi
 
 # Copies any extra libraries from this bootstrapper image to the extra-lib empty-dir
 if [[ -d /${BOOTSTRAP_LIBS} && ! -z `ls -A /${BOOTSTRAP_LIBS}` ]] ; then
-    echo " == We have a Additional libs, we surcharge default configuration files"
+    echo "We have a Additional libs, we surcharge default configuration files"
     cp -v ${BOOTSTRAP_LIBS}/* $CASSANDRA_LIBS/
    fi
 
 if [ -f ${CONFIGMAP}/pre_run.sh ]; then
-    echo " == We found pre_run.sh script, we execute it"
+    echo "We found pre_run.sh script, we execute it"
     ${CONFIGMAP}/pre_run.sh
 fi
 

--- a/docker/bootstrap/dgoss/util.sh
+++ b/docker/bootstrap/dgoss/util.sh
@@ -53,7 +53,6 @@ function createCassandraBootstrapContainer {
            -e HOSTNAME=cassandra-seb-dc1-rack1-0 \
            -e POD_NAME=cassandra-demo-dc1-rack1-0 \
            -e POD_NAMESPACE=ns \
-           -e SERVICE_NAME=cassandra-demo \
            -e CASSANDRA_GC_STDOUT=true \
            -e CASSANDRA_NUM_TOKENS=32 \
            -e CASSANDRA_DC=dc1 \
@@ -77,7 +76,6 @@ function createCassandraBootstrapContainerNoExtraLib {
            -e HOSTNAME=cassandra-seb-dc1-rack1-0 \
            -e POD_NAME=cassandra-demo-dc1-rack1-0 \
            -e POD_NAMESPACE=ns \
-           -e SERVICE_NAME=cassandra-demo \
            -e CASSANDRA_GC_STDOUT=true \
            -e CASSANDRA_ENABLE_JOLOKIA=false \
            -e CASSANDRA_EXPORTER_AGENT=false \
@@ -101,7 +99,6 @@ function createCassandraBootstrapContainerWithConfigMap {
            -e HOSTNAME=cassandra-seb-dc1-rack1-0 \
            -e POD_NAME=cassandra-demo-dc1-rack1-0 \
            -e POD_NAMESPACE=ns \
-           -e SERVICE_NAME=cassandra-demo \
            -e CASSANDRA_GC_STDOUT=true \
            -e CASSANDRA_NUM_TOKENS=32 \
            -e CASSANDRA_DC=dc1 \

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -82,21 +82,6 @@ func generateCassandraService(cc *api.CassandraCluster, labels map[string]string
 			ClusterIP: v1.ClusterIPNone,
 			Ports: []v1.ServicePort{
 				v1.ServicePort{
-					Port:     cassandraIntraNodePort,
-					Protocol: v1.ProtocolTCP,
-					Name:     cassandraIntraNodeName,
-				},
-				v1.ServicePort{
-					Port:     cassandraIntraNodeTLSPort,
-					Protocol: v1.ProtocolTCP,
-					Name:     cassandraIntraNodeTLSName,
-				},
-				v1.ServicePort{
-					Port:     cassandraJMX,
-					Protocol: v1.ProtocolTCP,
-					Name:     cassandraJMXName,
-				},
-				v1.ServicePort{
 					Port:     cassandraPort,
 					Protocol: v1.ProtocolTCP,
 					Name:     cassandraPortName,

--- a/test/e2e/cassandracluster_test.go
+++ b/test/e2e/cassandracluster_test.go
@@ -208,12 +208,9 @@ func cassandraClusterServiceTest(t *testing.T, f *framework.Framework, ctx *fram
 	assert.Equal(t, kind, clusterService.ObjectMeta.OwnerReferences[0].Kind)
 	assert.Equal(t, cluster.Name, clusterService.ObjectMeta.OwnerReferences[0].Name)
 	assert.True(t, *clusterService.ObjectMeta.OwnerReferences[0].Controller)
-	assert.Equal(t, 4, len(clusterService.Spec.Ports))
+	assert.Equal(t, 1, len(clusterService.Spec.Ports))
 
 	assertServiceExposesPort(t, &clusterService, "cql", 9042)
-	assertServiceExposesPort(t, &clusterService, "intra-node", 7000)
-	assertServiceExposesPort(t, &clusterService, "intra-node-tls", 7001)
-	assertServiceExposesPort(t, &clusterService, "jmx-port", 7199)
 
 	assert.Equal(t, 1, len(monitoringService.ObjectMeta.OwnerReferences))
 	assert.Equal(t, kind, monitoringService.ObjectMeta.OwnerReferences[0].Kind)


### PR DESCRIPTION
This PR removes Intranode and JMX ports from the Service, this way they are not proxyfied by Istio. When Istio proxyfies internodes ports it prevents local connections which is needed by Gossip protocol

```
HOST:PORT                                                           STATUS       SERVER      CLIENT           AUTHN POLICY                                 DESTINATION RULE
cassandra-e2e-exporter-jmx.cassandra-e2e.svc.cluster.local:9500     OK           STRICT      ISTIO_MUTUAL     /default                                     istio-system/default
cassandra-e2e.cassandra-e2e.svc.cluster.local:9042                  OK           STRICT      ISTIO_MUTUAL     /default                                     istio-system/default
cassandra-reaper.cassandra-e2e.svc.cluster.local:8080               OK           STRICT      ISTIO_MUTUAL     /default                                     istio-system/default
```

The proxy configuration that shows the TLS context can be found at https://pastebin.com/raw/jEmxXpwv